### PR TITLE
Output runfiles from rule

### DIFF
--- a/internal/openapi_generator.bzl
+++ b/internal/openapi_generator.bzl
@@ -100,9 +100,10 @@ def _impl(ctx):
 
     srcs = declared_dir.path
 
-    return DefaultInfo(files = depset([
-        declared_dir,
-    ]))
+    return DefaultInfo(
+        files = depset([declared_dir]),
+        runfiles = ctx.runfiles(files = [declared_dir]),
+    )
 
 # taken from rules_scala
 def _collect_jars(targets):


### PR DESCRIPTION
This lets other rules depend on this rule to produce the generated runfiles they need.